### PR TITLE
Add "get position" method available in neutralino window api

### DIFF
--- a/src/windows/Windows.ts
+++ b/src/windows/Windows.ts
@@ -8,6 +8,11 @@ type WindowSize = {
     resizable?: boolean;
 }
 
+type WindowPosition = {
+    x: number;
+    y: number;
+}
+
 type WindowOptions = WindowSize & {
     title?: string;
     icon?: string;
@@ -125,6 +130,11 @@ interface Window
      * windows have incorrect sizes, you can (and by that I mean you should) provide them manually
      */
     center(width?: number, height?: number): Promise<void>;
+
+    /**
+     * Gets window position
+    */
+    getPosition(): Promise<WindowPosition>
 }
 
 declare const Neutralino;


### PR DESCRIPTION
Neutralino provides a getPosition method to get the current position of a window, this is very useful in multi-window apps to save the position of the previous window.

- the getPosition method was added to the Window interface to directly access this method.
- a WindowPosition type was defined

https://neutralino.js.org/docs/api/window#windowgetposition